### PR TITLE
Added error emitter to s3 read stream

### DIFF
--- a/s3-files.js
+++ b/s3-files.js
@@ -43,6 +43,10 @@ s3Files.createFileStream = function (keyStream) {
       var params = { Bucket: self.bucket, Key: file };
       var s3File = self.s3.getObject(params).createReadStream();
 
+      s3File.on('error', function(err) {
+        rs.emit('error', err);
+      });
+
       s3File.pipe(
         concat(function buffersEmit (buffer) {
           // console.log('buffers concatenated, emit data for ', file);

--- a/s3-files.js
+++ b/s3-files.js
@@ -43,10 +43,6 @@ s3Files.createFileStream = function (keyStream) {
       var params = { Bucket: self.bucket, Key: file };
       var s3File = self.s3.getObject(params).createReadStream();
 
-      s3File.on('error', function(err) {
-        rs.emit('error', err);
-      });
-
       s3File.pipe(
         concat(function buffersEmit (buffer) {
           // console.log('buffers concatenated, emit data for ', file);
@@ -61,6 +57,12 @@ s3Files.createFileStream = function (keyStream) {
             rs.emit('end');
           }
         });
+
+      s3File
+        .on('error', function(err) {
+          rs.emit('error', err);
+        });
+
     });
   return rs;
 };


### PR DESCRIPTION
When used with s3-zip, there were no errors being emitted when an invalid key was requested, crashing the app. This fixes that and allows them to be handled.

Before:

 [ERROR] NoSuchKey: The specified key does not exist.
    at Request.extractError (workspace/project/node_modules/s3-files/node_modules/aws-sdk/lib/services/s3.js:473:35)
    at Request.callListeners (workspace/project/node_modules/s3-files/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (workspace/project/node_modules/s3-files/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
 .................
[nodemon] app crashed - waiting for file changes before starting...


After: (catching the error, console.log'ing it)
{ [NoSuchKey: The specified key does not exist.]
  message: 'The specified key does not exist.',
  code: 'NoSuchKey',
  region: null,
  time: Thu Jun 16 2016 10:12:18 GMT-0700 (PDT),
  requestId: 'B0B2CE7B622695DD',
  extendedRequestId: 'k35odVehQXydvca+jct1NmsTyl3yOpnwma6hqfB922xN2fYYZxH/cuTvOopoSFBUFMZZcUKwDKU=',
  cfId: undefined,
  statusCode: 404,
  retryable: false,
  retryDelay: 2.2807395551353693 }