### PR TITLE
Less reliance on the specific folder.

### DIFF
--- a/s3-files.js
+++ b/s3-files.js
@@ -46,7 +46,7 @@ s3Files.createFileStream = function (keyStream) {
       s3File.pipe(
         concat(function buffersEmit (buffer) {
           // console.log('buffers concatenated, emit data for ', file);
-          rs.emit('data', { data: buffer, path: file.replace(self.folder, '') });
+          rs.emit('data', { data: buffer, path: file.replace(/^.*[\\\/]/, '') });
         })
       );
       s3File


### PR DESCRIPTION
Thanks for this handy module, got me set up with zipping files in S3 very quickly so thanks for your work on this and https://github.com/orangewise/s3-zip - I have some changes coming to that too :)

## Changes 
Don't specifically replace the folder as it makes it impossible to zip up a set of files that reside in different folders, this way it will always just return the file name from the path. It's now removing everything before the last `/`.

I can't see any reason not to totally remove the folder parameter, or certainly make it optional as 
in https://github.com/orangewise/s3-files/pull/2 - there shouldn't be any reason why you can't just specify the full path of the file in the array (cause we all know they're not really folders 😉  )

This actually goes hand in hand with https://github.com/orangewise/s3-files/pull/2 @max-preuschen

