### PR TITLE
pass s3 client to connect method

### DIFF
--- a/s3-files.js
+++ b/s3-files.js
@@ -8,10 +8,17 @@ module.exports = s3Files
 
 s3Files.connect = function (opts) {
   var self = this
-  AWS.config.update({
-    'region': opts.region
-  })
-  self.s3 = new AWS.S3()
+
+  if('s3' in opts) {
+    self.s3 = opts.s3
+
+  } else {
+    AWS.config.update({
+      'region': opts.region
+    })
+    self.s3 = new AWS.S3()
+  }
+
   self.bucket = opts.bucket
   return self
 }


### PR DESCRIPTION
Sometimes we need to pass more options to the S3 client in different projects. This PR allows users to pass their pre-connected S3 client to the module.