### PR TITLE
Do not require a trailing slash for the folder parameter.

### DIFF
--- a/s3-files.js
+++ b/s3-files.js
@@ -2,6 +2,7 @@ var Stream = require('stream')
 var AWS = require('aws-sdk')
 var streamify = require('stream-array')
 var concat = require('concat-stream')
+var path = require('path')
 
 var s3Files = {}
 module.exports = s3Files
@@ -27,7 +28,7 @@ s3Files.createKeyStream = function (folder, keys) {
   var paths = []
   keys.forEach(function (key) {
     if (folder) {
-      paths.push(folder + key)
+      paths.push(path.join(folder, key))
     } else {
       paths.push(key)
     }

--- a/test/test_index.js
+++ b/test/test_index.js
@@ -30,6 +30,19 @@ t.test('keyStream', function (child) {
   })
 })
 
+t.test('keyStream without folder having trailing slash', function (child) {
+  var keyStream = s3Files.createKeyStream('folder', ['a', 'b'])
+  var cnt = 0
+  keyStream.on('data', function (chunk) {
+    if (cnt === 0) child.equal(chunk.toString(), 'folder/a')
+    if (cnt === 1) child.equal(chunk.toString(), 'folder/b')
+    cnt++
+  })
+  keyStream.on('end', function () {
+    child.end()
+  })
+})
+
 t.test('keyStream without folder', function (child) {
   var keyStream = s3Files.createKeyStream('', ['a', 'b'])
   var cnt = 0


### PR DESCRIPTION
When `folder` is given a value without a trailing slash, the `createKeyStream` would not correctly join the paths.

This PR adds a failing test and the implementation that fixes it. Addresses much confusion among users of `s3-zip` where people (like myself) did not put a trailing slash at the end.

Related issues in `s3-zip`:

- https://github.com/orangewise/s3-zip/issues/26
- https://github.com/orangewise/s3-zip/issues/53
- https://github.com/orangewise/s3-zip/issues/15