### PR TITLE
Handle GetObjectCommand throwing an error

### DIFF
--- a/s3-files.js
+++ b/s3-files.js
@@ -51,30 +51,35 @@ s3Files.createFileStream = function (keyStream, preserveFolderPath) {
 
     // console.log('->file', file);
     const params = { Bucket: self.bucket, Key: file }
-    const { Body: s3File } = await self.s3.send(new GetObjectCommand(params))
+    try {
+      const { Body: s3File } = await self.s3.send(new GetObjectCommand(params))
 
-    s3File.pipe(
-      concat(function buffersEmit (buffer) {
-        // console.log('buffers concatenated, emit data for ', file);
-        const path = preserveFolderPath ? file : file.replace(/^.*[\\/]/, '')
-        rs.emit('data', { data: buffer, path })
+      s3File.pipe(
+        concat(function buffersEmit (buffer) {
+          // console.log('buffers concatenated, emit data for ', file);
+          const path = preserveFolderPath ? file : file.replace(/^.*[\\/]/, '')
+          rs.emit('data', { data: buffer, path })
+        })
+      )
+      s3File.on('end', function () {
+        fileCounter -= 1
+        if (keyStream.isPaused()) {
+          keyStream.resume()
+        }
+        if (fileCounter < 1) {
+          // console.log('all files processed, emit end');
+          rs.emit('end')
+        }
       })
-    )
-    s3File.on('end', function () {
-      fileCounter -= 1
-      if (keyStream.isPaused()) {
-        keyStream.resume()
-      }
-      if (fileCounter < 1) {
-        // console.log('all files processed, emit end');
-        rs.emit('end')
-      }
-    })
 
-    s3File.on('error', function (err) {
-      err.file = file
-      rs.emit('error', err)
-    })
+      s3File.on('error', function (err) {
+        err.file = file
+        rs.emit('error', err)
+      })
+    } catch (e) {
+      e.file = file
+      rs.emit('error', e)
+    }
   })
   return rs
 }


### PR DESCRIPTION
An example would be where the S3 Key does not exist, this throws a `NoSuchKey` error.

In Node.js versions >= 15 an unhandled promise error causes the process to exit which is mostly not the desired behaviour of an application.

I've added a `try { } catch {}` block to handle this promise error and emit it as an error on the stream instead.