### PR TITLE
fix: handle s3 GetObject rejection with proper cleanup

### DIFF
--- a/s3-files.js
+++ b/s3-files.js
@@ -51,30 +51,42 @@ s3Files.createFileStream = function (keyStream, preserveFolderPath) {
 
     // console.log('->file', file);
     const params = { Bucket: self.bucket, Key: file }
-    const { Body: s3File } = await self.s3.send(new GetObjectCommand(params))
+    try {
+      const { Body: s3File } = await self.s3.send(new GetObjectCommand(params))
 
-    s3File.pipe(
-      concat(function buffersEmit (buffer) {
-        // console.log('buffers concatenated, emit data for ', file);
-        const path = preserveFolderPath ? file : file.replace(/^.*[\\/]/, '')
-        rs.emit('data', { data: buffer, path })
+      s3File.pipe(
+        concat(function buffersEmit (buffer) {
+          // console.log('buffers concatenated, emit data for ', file);
+          const path = preserveFolderPath ? file : file.replace(/^.*[\\/]/, '')
+          rs.emit('data', { data: buffer, path })
+        })
+      )
+      s3File.on('end', function () {
+        fileCounter -= 1
+        if (keyStream.isPaused()) {
+          keyStream.resume()
+        }
+        if (fileCounter < 1) {
+          // console.log('all files processed, emit end');
+          rs.emit('end')
+        }
       })
-    )
-    s3File.on('end', function () {
+
+      s3File.on('error', function (err) {
+        err.file = file
+        rs.emit('error', err)
+      })
+    } catch (err) {
       fileCounter -= 1
       if (keyStream.isPaused()) {
         keyStream.resume()
       }
-      if (fileCounter < 1) {
-        // console.log('all files processed, emit end');
-        rs.emit('end')
-      }
-    })
-
-    s3File.on('error', function (err) {
       err.file = file
       rs.emit('error', err)
-    })
+      if (fileCounter < 1) {
+        rs.emit('end')
+      }
+    }
   })
   return rs
 }


### PR DESCRIPTION
Wrap the s3.send(GetObjectCommand) call in try-catch to handle
promise rejections (e.g. NoSuchKey) that would otherwise cause
unhandled rejection crashes in Node 15+.

Compared to PR #26, this also decrements fileCounter and resumes
keyStream in the catch block, ensuring the stream properly emits
'end' after errors and doesn't leave the keyStream permanently paused.

https://claude.ai/code/session_01XHcgh6qwd8BCE7YGhfEb8a